### PR TITLE
Fix: Agrega el ThemeContext en las demás páginas del portafolio 

### DIFF
--- a/src/pages/home.rs
+++ b/src/pages/home.rs
@@ -12,7 +12,6 @@ pub fn Home() -> impl IntoView {
             <Hero />
             <div class="h-86 z-20 relative overflow-hidden">
                 <Separator />
-                //<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 320"><path fill="hsl(222.2, 84%, 4.9%)" fill-opacity="1" d="M0,224L80,234.7C160,245,320,267,480,266.7C640,267,800,245,960,224C1120,203,1280,181,1360,170.7L1440,160L1440,320L1360,320C1280,320,1120,320,960,320C800,320,640,320,480,320C320,320,160,320,80,320L0,320Z"></path></svg>
             </div>
             <main class="relative z-30 min-h-screen w-full bg-background">
                 <div class="container mx-auto py-8 px-4 sm:px-6">

--- a/src/pages/oss_contributions.rs
+++ b/src/pages/oss_contributions.rs
@@ -1,9 +1,11 @@
 use bon::Builder;
 use crate::components::{GithubIcon, Header, LinkIcon, StarIcon};
 use leptos::prelude::*;
+use crate::context::provide_theme_context;
 
 #[component]
 pub fn OSSContributions() -> impl IntoView {
+    let _ = provide_theme_context();
     let contributions = vec![
         Contribution::builder()
             .title("Teloxide Contribution")

--- a/src/pages/terms_and_conditions.rs
+++ b/src/pages/terms_and_conditions.rs
@@ -1,9 +1,11 @@
 use leptos::prelude::*;
 use leptos_fluent::move_tr;
 use crate::components::{Footer, Header};
+use crate::context::provide_theme_context;
 
 #[component]
 pub fn TermsAndConditions() -> impl IntoView {
+    let _ = provide_theme_context();
     view! {
         <div class="min-h-screen bg-background text-gray-900 dark:text-gray-200">
             <Header />


### PR DESCRIPTION
Agrega el ThemeContext en las demás páginas del portafolio para evitar el panic por su ausencia